### PR TITLE
fix: Update use instructions for lumberbot-app

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ code {
     </div>
 
   <h2>Use MrMeeseeks on Your Own repo</h2>
-  <p>Head <a href='https://github.com/apps/meeseeksdev/installations/new/'>there</a> and activate the bot on the repository you'd like.<p>
+  <p>Head <a href='https://github.com/apps/lumberbot-app/'>here</a> and install and activate the bot on the repository you'd like.<p>
 
   <p>Now any commiter on said repository can say <code>@meeseeksdev backport to
       [BRANCHNAME]</code> on a merged PR, and Mr Meeseeks will attempt to


### PR DESCRIPTION
* https://github.com/apps/meeseeksdev/ no longer exists, and has been replaced by https://github.com/apps/lumberbot-app/.